### PR TITLE
Remove MF_ID

### DIFF
--- a/libs/src/haxe/js/metapage/Constants.hx
+++ b/libs/src/haxe/js/metapage/Constants.hx
@@ -6,7 +6,6 @@ class Constants
 	inline public static var METAPAGE_KEY_DEFINITION = 'metapage/definition';
 	inline public static var METAPAGE_KEY_STATE      = 'metapage/state';
 	inline public static var URL_PARAM_DEBUG         = 'MP_DEBUG';
-	inline public static var URL_PARAM_METAFRAME_ID  = 'MF_ID';
 
 	public static var VERSIONS_ALL :Array<MetaLibsVersion> = macros.AbstractEnumTools.getValues(js.metapage.MetaLibsVersion);
 	public static var VERSION :MetaLibsVersion = VERSIONS_ALL[VERSIONS_ALL.length - 1];

--- a/libs/src/haxe/js/metapage/client/Metaframe.hx
+++ b/libs/src/haxe/js/metapage/client/Metaframe.hx
@@ -45,7 +45,6 @@ class Metaframe extends EventEmitter
 		super();
 		debug = MetapageTools.getUrlParamDEBUG();
 		_isIframe = isIframe();
-		// this.name = MetapageTools.getUrlParamMF_ID();
 
 		if (!_isIframe) {
 			//Don't add any of the machinery, it only works if we're iframes.

--- a/libs/src/haxe/js/metapage/client/Metapage.hx
+++ b/libs/src/haxe/js/metapage/client/Metapage.hx
@@ -967,7 +967,6 @@ class IFrameRpcClient extends EventEmitter
 
 		// Add the custom URL params
 		var urlBlob = new js.html.URL(this.url);
-		urlBlob.searchParams.set(URL_PARAM_METAFRAME_ID, iframeId);
 		if (debug) {
 			urlBlob.searchParams.set(URL_PARAM_DEBUG, '1');
 		}

--- a/libs/src/haxe/js/metapage/client/MetapageTools.hx
+++ b/libs/src/haxe/js/metapage/client/MetapageTools.hx
@@ -153,11 +153,6 @@ class MetapageTools
 		});
 	}
 
-	public static function getUrlParamMF_ID() :String
-	{
-		return new js.html.URLSearchParams(js.Browser.window.location.search).get(URL_PARAM_METAFRAME_ID);
-	}
-
 	public static function generateMetaframeId(?length :Int = 8) :MetaframeId
 	{
 		return new MetaframeId(generateId(length));


### PR DESCRIPTION
Remove MF_ID env var, it serves no purpose and is confusing, and can break things (unexpected URL params should be avoided)