### PR TITLE
Allow updating definition automatically and only via event

### DIFF
--- a/app/libs/justfile
+++ b/app/libs/justfile
@@ -77,12 +77,12 @@ dev:
 
 # npm link the package in dist for local development. In the other project: 'npm link @metapages/metapage'
 @link: unlink build
-    cd dist/{{NPM_MODULE}} && npm link
+    cd dist && npm link
     echo -e "👉 in the other project: 'npm link {{NPM_MODULE}}'"
 
 # unlink the package in dist from local development. You probably don't ever need to do this
 @unlink:
-    cd dist/{{NPM_MODULE}} && npm unlink
+    cd dist && npm unlink
 
 # Write library versions to the place where jekyll can consume: docs/_data/versions.yml
 _versions-write-versions-to-jekyll:
@@ -98,7 +98,7 @@ _versions-write-versions-to-jekyll:
     })()
 
 # List all published versions
-@npm_list:
+@list:
     npm view {{NPM_MODULE}} versions --json
 
 # If the version does not exist, publish the packages (metaframe+metapage)

--- a/app/libs/package.json
+++ b/app/libs/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@metapages/metapage",
     "public": true,
-    "version": "0.5.11",
+    "version": "0.5.12",
     "description": "Connect web pages together",
     "repository": "https://github.com/metapages/metapage",
     "homepage": "https://metapages.org/",

--- a/app/libs/package.json
+++ b/app/libs/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@metapages/metapage",
     "public": true,
-    "version": "0.5.10",
+    "version": "0.5.11",
     "description": "Connect web pages together",
     "repository": "https://github.com/metapages/metapage",
     "homepage": "https://metapages.org/",

--- a/app/libs/src/index.ts
+++ b/app/libs/src/index.ts
@@ -6,4 +6,5 @@ export * from "./metapage/v0_3/all";
 export * from "./metapage/v0_3/JsonRpcMethods";
 export * from "./metapage/Shared";
 export * from "./metapage/MetapageIFrameRpcClient";
+export * from "./metapage/MetapageEvents";
 export const version = VERSION;

--- a/app/libs/src/metapage/Metaframe.ts
+++ b/app/libs/src/metapage/Metaframe.ts
@@ -9,11 +9,11 @@ import {
   JsonRpcMethodsFromChild,
   SetupIframeServerResponseData,
   MinimumClientMessage,
-  HashParamsUpdatePayload,
 } from "./v0_3/JsonRpcMethods";
 import { getUrlParamDEBUG, stringToRgb, log as MetapageToolsLog, merge, pageLoaded } from "./MetapageTools";
 import { isIframe } from "./Shared";
 import { MetaframeId } from './v0_0_1/all';
+import { MetapageEventUrlHashUpdate } from "./MetapageEvents";
 
 // TODO combine/unify MetaframeEvents and MetaframeLoadingState
 enum MetaframeLoadingState {
@@ -122,7 +122,7 @@ export class Metaframe extends EventEmitter<MetaframeEvents | JsonRpcMethodsFrom
           ? this._parentVersion
           : "unknown"}) registered`);
 
-      this._inputPipeValues = params.state != null && params.state.inputs != null
+      this._inputPipeValues = params.state && params.state.inputs
         ? params.state.inputs
         : this._inputPipeValues;
 
@@ -182,7 +182,7 @@ export class Metaframe extends EventEmitter<MetaframeEvents | JsonRpcMethodsFrom
       return;
     }
     this.logInternal(
-      o, color != null
+      o, color
       ? color
       : this.color);
   }
@@ -208,12 +208,12 @@ export class Metaframe extends EventEmitter<MetaframeEvents | JsonRpcMethodsFrom
       s = JSON.stringify(o);
     }
 
-    color = color != null
+    color = color
       ? color + ""
       : color;
 
     s = (
-      this.id != null
+      this.id
         ? `Metaframe[${this.id}] `
         : "") + `${s}`;
     MetapageToolsLog(s, color, backgroundColor);
@@ -237,7 +237,7 @@ export class Metaframe extends EventEmitter<MetaframeEvents | JsonRpcMethodsFrom
     //will always get a value if it exists
     if (event === MetaframeEvents.Inputs) {
       window.setTimeout(() => {
-        if (this._inputPipeValues != null) {
+        if (this._inputPipeValues) {
           listener(this._inputPipeValues);
         }
       }, 0);
@@ -290,7 +290,7 @@ export class Metaframe extends EventEmitter<MetaframeEvents | JsonRpcMethodsFrom
   }
 
   public getInput(pipeId: MetaframePipeId): any {
-    console.assert(pipeId != null);
+    console.assert(pipeId);
     return this._inputPipeValues[pipeId];
   }
 
@@ -299,7 +299,7 @@ export class Metaframe extends EventEmitter<MetaframeEvents | JsonRpcMethodsFrom
   }
 
   public getOutput(pipeId: MetaframePipeId): any {
-    console.assert(pipeId != null);
+    console.assert(pipeId);
     return this._outputPipeValues[pipeId];
   }
 
@@ -309,8 +309,8 @@ export class Metaframe extends EventEmitter<MetaframeEvents | JsonRpcMethodsFrom
    * @param updateBlob :any        [description]
    */
   public setOutput(pipeId: MetaframePipeId, updateBlob: any): void {
-    console.assert(pipeId != null);
-    console.assert(updateBlob != null);
+    console.assert(pipeId);
+    console.assert(updateBlob);
 
     var outputs: MetaframeInputMap = {};
     outputs[pipeId] = updateBlob;
@@ -339,8 +339,8 @@ export class Metaframe extends EventEmitter<MetaframeEvents | JsonRpcMethodsFrom
   }
 
   /** Tell the parent metapage our hash params changed */
-  _onHashUrlChange(_: HashChangeEvent) :void {
-    const payload :HashParamsUpdatePayload = {
+  _onHashUrlChange(_: HashChangeEvent): void {
+    const payload: MetapageEventUrlHashUpdate = {
       hash: window.location.hash,
       metaframe: this.id as MetaframeId,
     }
@@ -359,7 +359,7 @@ export class Metaframe extends EventEmitter<MetaframeEvents | JsonRpcMethodsFrom
       };
       window.parent.postMessage(message, "*");
     } else {
-      this.error("Cannot send JSON-RPC window message: there is no window.parent which means we are not an iframe");
+      this.log("Cannot send JSON-RPC window message: there is no window.parent which means we are not an iframe");
     }
   }
 
@@ -427,7 +427,7 @@ export class MetaframePlugin {
 
   onState(listener: (_: any) => void): () => void {
     const disposer = this._metaframe.onInput(METAPAGE_KEY_STATE, listener);
-    if (this.getState() != null) {
+    if (this.getState()) {
       listener(this.getState());
     }
     return disposer;
@@ -443,7 +443,7 @@ export class MetaframePlugin {
 
   onDefinition(listener: (a: any) => void): () => void {
     var disposer = this._metaframe.onInput(METAPAGE_KEY_DEFINITION, listener);
-    if (this.getDefinition() != null) {
+    if (this.getDefinition()) {
       listener(this.getDefinition());
     }
     return disposer;

--- a/app/libs/src/metapage/Metaframe.ts
+++ b/app/libs/src/metapage/Metaframe.ts
@@ -13,6 +13,7 @@ import {
 } from "./v0_3/JsonRpcMethods";
 import { getUrlParamDEBUG, stringToRgb, log as MetapageToolsLog, merge, pageLoaded } from "./MetapageTools";
 import { isIframe } from "./Shared";
+import { MetaframeId } from './v0_0_1/all';
 
 // TODO combine/unify MetaframeEvents and MetaframeLoadingState
 enum MetaframeLoadingState {
@@ -341,7 +342,7 @@ export class Metaframe extends EventEmitter<MetaframeEvents | JsonRpcMethodsFrom
   _onHashUrlChange(_: HashChangeEvent) :void {
     const payload :HashParamsUpdatePayload = {
       hash: window.location.hash,
-      metaframe: this.id,
+      metaframe: this.id as MetaframeId,
     }
     this.sendRpc(JsonRpcMethodsFromChild.HashParamsUpdate, payload);
   }

--- a/app/libs/src/metapage/Metapage.ts
+++ b/app/libs/src/metapage/Metapage.ts
@@ -78,10 +78,13 @@ export class Metapage extends MetapageShared {
 
   // Event literals for users to listen to events
   public static readonly DEFINITION = MetapageEvents.Definition;
+  public static readonly DEFINITION_UPDATE_REQUEST = MetapageEvents.DefinitionUpdateRequest;
+  public static readonly ERROR = MetapageEvents.Error;
   public static readonly INPUTS = MetapageEvents.Inputs;
+  public static readonly MESSAGE = MetapageEvents.Message;
   public static readonly OUTPUTS = MetapageEvents.Outputs;
   public static readonly STATE = MetapageEvents.State;
-  public static readonly ERROR = MetapageEvents.Error;
+  public static readonly URL_HASH_UPDATE = MetapageEvents.UrlHashUpdate;
 
   public static from(metaPageDef: any, inputs?: any): Metapage {
     if (metaPageDef == null) {
@@ -1051,7 +1054,7 @@ const bindPlugin = async (metapage: Metapage, plugin: MetapageIFrameRpcClient) =
       if (metaframeDef.outputs) {
         var disposer = plugin.onOutput(METAPAGE_KEY_DEFINITION, definition => {
           // trace('_metapage.setDefinition, definition=${definition}');
-          metapage.emit(MetapageEvents.DefinitionUpdateRequest, definition)
+          metapage.emit(MetapageEvents.DefinitionUpdateRequest, definition);
           // metapage.setDefinition(definition);
         });
         plugin._disposables.push(disposer);

--- a/app/libs/src/metapage/Metapage.ts
+++ b/app/libs/src/metapage/Metapage.ts
@@ -244,11 +244,6 @@ export class Metapage extends MetapageShared {
   }
 
   public setDefinition(def: any, state?: MetapageState): Metapage {
-    // If the window hasn't finished loading, throw an error.
-    // if (!isPageLoaded()) {
-    //   throw new Error(ERROR_MESSAGE_PAGE_NOT_LOADED);
-    // }
-    console.log('newDefinition', def);
     // Some validation
     // can metaframes and plugins share IDs? No.
     const newDefinition: MetapageDefinition = convertToCurrentDefinition(def);
@@ -971,7 +966,6 @@ export class Metapage extends MetapageShared {
             //   - compare metapage.getDefinition() with any updates outside of this
             //     context to decide wether to re-render or recreate
             const hashParamsUpdatePayload: MetapageEventUrlHashUpdate = jsonrpc.params;
-            console.log(`reemitting jsonrpc.params`, hashParamsUpdatePayload);
             const url = new URL(metaframeOrPlugin.url);
             url.hash = hashParamsUpdatePayload.hash;
             // Update the local metaframe client reference
@@ -1027,7 +1021,6 @@ export class Metapage extends MetapageShared {
    * @return Promise<boolean>
    */
 const bindPlugin = async (metapage: Metapage, plugin: MetapageIFrameRpcClient) => {
-  console.log(`bindPlugin plugin${plugin.id}`);
   //   1) check for metapage/definition inputs and outputs
   //		- if found, wire up listeners and responses and send current definition
   //   2) check for metapage/state inputs and outputs
@@ -1044,7 +1037,6 @@ const bindPlugin = async (metapage: Metapage, plugin: MetapageIFrameRpcClient) =
     // on getting a metapage/definition value, set that
     // value on the metapage itself.
     if (plugin.hasPermissionsDefinition()) {
-      console.log(`bindPlugin hasPermissionsDefinition plugin${plugin.id}`);
       var disposer = metapage.addListenerReturnDisposer(MetapageEvents.Definition, definition => {
         plugin.setInput(METAPAGE_KEY_DEFINITION, definition.definition);
       });

--- a/app/libs/src/metapage/Metapage.ts
+++ b/app/libs/src/metapage/Metapage.ts
@@ -17,7 +17,6 @@ import {
   JsonRpcMethodsFromChild,
   MinimumClientMessage,
   SetupIframeClientAckData,
-  OtherEvents,
 } from "./v0_3/JsonRpcMethods";
 import {
 
@@ -112,7 +111,7 @@ export class Metapage extends MetapageShared {
 
   _id: MetapageId;
   // Easier to ensure this value is never null|undefined
-  _definition: MetapageDefinition = {version:Versions.V0_3, metaframes:{}};
+  _definition: MetapageDefinition = { version: Versions.V0_3, metaframes: {} };
   _state: MetapageState = emptyState();
   _metaframes: {
     [key: string]: MetapageIFrameRpcClient;
@@ -212,7 +211,7 @@ export class Metapage extends MetapageShared {
     });
   }
 
-  addListenerReturnDisposer(event: MetapageEvents | OtherEvents, listener: ListenerFn<any[]>): () => void {
+  addListenerReturnDisposer(event: MetapageEvents, listener: ListenerFn<any[]>): () => void {
     super.addListener(event, listener);
     const disposer = () => {
       super.removeListener(event, listener);

--- a/app/libs/src/metapage/MetapageEvents.ts
+++ b/app/libs/src/metapage/MetapageEvents.ts
@@ -1,0 +1,40 @@
+
+import {
+    MetaframeId,
+    MetapageDefinition
+} from "./v0_3/all";
+import { MetapageIFrameRpcClient } from "./MetapageIFrameRpcClient";
+
+export enum MetapageEvents {
+    Inputs = "inputs",
+    Outputs = "outputs",
+    State = "state",
+    // The definition has already changed e.g. a metaframe changes its hash params
+    // so the current definition now contains that change
+    Definition = "definition",
+    // A plugin is requesting to modify the definition
+    // This is not automatically processed, the context of the metapage decides what
+    // to do with this update (apply, recreate metapage, ignore etc)
+    DefinitionUpdateRequest = "definitionupdaterequest",
+    Error = "error",
+    // when a metaframe wants to tell the metapage of the new URL (for saving state/config)
+    UrlHashUpdate = "urlhashupdate",
+    // general event, all events are emitted in their raw form to this namespace
+    Message = "Message",
+}
+
+
+export interface MetapageEventDefinition {
+    definition: MetapageDefinition;
+    metaframes: {
+        [key: string]: MetapageIFrameRpcClient;
+    };
+    plugins?: {
+        [key: string]: MetapageIFrameRpcClient;
+    };
+}
+
+export type MetapageEventUrlHashUpdate = {
+    metaframe: MetaframeId;
+    hash: string;
+}

--- a/app/libs/src/metapage/MetapageIFrameRpcClient.ts
+++ b/app/libs/src/metapage/MetapageIFrameRpcClient.ts
@@ -23,7 +23,8 @@ import {
   pageLoaded,
 } from "./MetapageTools";
 import { JsonRpcRequest } from "./jsonrpc2";
-import { MetapageEvents, MetapageShared } from "./Shared";
+import { MetapageShared } from "./Shared";
+import { MetapageEvents } from "./MetapageEvents";
 
 /**
  * Initialization sequence:
@@ -126,6 +127,7 @@ export class MetapageIFrameRpcClient extends EventEmitter<JsonRpcMethodsFromPare
     this.setOutputs = this.setOutputs.bind(this);
     this.setPlugin = this.setPlugin.bind(this);
     this.addListenerReturnDisposer = this.addListenerReturnDisposer.bind(this);
+    this.isDisposed = this.isDisposed.bind(this);
   }
 
   addListenerReturnDisposer(event: JsonRpcMethodsFromParent | MetapageEvents, listener: ListenerFn<any[]>): () => void {
@@ -276,6 +278,10 @@ export class MetapageIFrameRpcClient extends EventEmitter<JsonRpcMethodsFromPare
       }
     };
     return this.addListenerReturnDisposer(MetapageEvents.Outputs, fWrap);
+  }
+
+  public isDisposed() {
+    return this.inputs === undefined;
   }
 
   public dispose() {

--- a/app/libs/src/metapage/Shared.ts
+++ b/app/libs/src/metapage/Shared.ts
@@ -1,4 +1,4 @@
-import {EventEmitter} from "eventemitter3";
+import { EventEmitter } from "eventemitter3";
 import {
   JsonRpcMethodsFromParent,
 } from "./v0_3/JsonRpcMethods";
@@ -24,7 +24,7 @@ export const isIframe = (): boolean => {
   }
 };
 
-export class MetapageShared extends EventEmitter<MetapageEvents | JsonRpcMethodsFromParent | OtherEvents> {
+export class MetapageShared extends EventEmitter<MetapageEvents | JsonRpcMethodsFromParent> {
   public error(err: any) {
     throw 'Subclass should implement';
   }

--- a/app/libs/src/metapage/Shared.ts
+++ b/app/libs/src/metapage/Shared.ts
@@ -2,18 +2,11 @@ import { EventEmitter } from "eventemitter3";
 import {
   JsonRpcMethodsFromParent,
 } from "./v0_3/JsonRpcMethods";
-
-export enum MetapageEvents {
-  Inputs = "inputs",
-  Outputs = "outputs",
-  State = "state",
-  Definition = "definition",
-  Error = "error",
-  // when a metaframe wants to tell the metapage of the new URL (for saving state/config)
-  UrlHashUpdate = "urlhashupdate",
-  // general event, all events are emitted in their raw form to this namespace
-  Message = "Message",
-}
+import {
+  MetapageDefinition
+} from "./v0_3/all";
+import { Versions } from "./MetaLibsVersion";
+import { MetapageEvents } from "./MetapageEvents";
 
 export const isIframe = (): boolean => {
   //http://stackoverflow.com/questions/326069/how-to-identify-if-a-webpage-is-being-loaded-inside-an-iframe-or-directly-into-t
@@ -25,7 +18,19 @@ export const isIframe = (): boolean => {
 };
 
 export class MetapageShared extends EventEmitter<MetapageEvents | JsonRpcMethodsFromParent> {
+
+  // Easier to ensure this value is never null|undefined
+  _definition: MetapageDefinition = { version: Versions.V0_3, metaframes: {} };
+
+  constructor() {
+    super();
+    this.getDefinition = this.getDefinition.bind(this);
+  }
+
   public error(err: any) {
     throw 'Subclass should implement';
+  }
+  public getDefinition(): MetapageDefinition {
+    return this._definition;
   }
 };

--- a/app/libs/src/metapage/Shared.ts
+++ b/app/libs/src/metapage/Shared.ts
@@ -1,7 +1,6 @@
 import {EventEmitter} from "eventemitter3";
 import {
   JsonRpcMethodsFromParent,
-  OtherEvents,
 } from "./v0_3/JsonRpcMethods";
 
 export enum MetapageEvents {
@@ -9,7 +8,11 @@ export enum MetapageEvents {
   Outputs = "outputs",
   State = "state",
   Definition = "definition",
-  Error = "error"
+  Error = "error",
+  // when a metaframe wants to tell the metapage of the new URL (for saving state/config)
+  UrlHashUpdate = "urlhashupdate",
+  // general event, all events are emitted in their raw form to this namespace
+  Message = "Message",
 }
 
 export const isIframe = (): boolean => {

--- a/app/libs/src/metapage/jsonrpc2.ts
+++ b/app/libs/src/metapage/jsonrpc2.ts
@@ -3,13 +3,13 @@
 /** A string specifying the version of the JSON-RPC protocol. MUST be exactly "2.0". */
 export type JsonRpcVersion = "2.0";
 
-/** Method names that begin with the word rpc followed by a period character 
+/** Method names that begin with the word rpc followed by a period character
  * (U+002E or ASCII 46) are reserved for rpc-internal methods and extensions
  *  and MUST NOT be used for anything else. */
 export type JsonRpcReservedMethod = string;
 
 /** An identifier established by the Client that MUST contain a string, Number,
- *  or NULL value if included. If it is not included it is assumed to be a 
+ *  or NULL value if included. If it is not included it is assumed to be a
  *  notification. The value SHOULD normally not be Null and Numbers SHOULD
  *  NOT contain fractional parts [2] */
 export type JsonRpcId = number | string | void;
@@ -18,12 +18,12 @@ export interface JsonRpcRequest<T> {
   jsonrpc: JsonRpcVersion;
   method: string;
   id: JsonRpcId;
-  params?: T; 
+  params?: T;
 }
 
 export interface JsonRpcNotification<T> extends JsonRpcResponse<T> {
   jsonrpc: JsonRpcVersion;
-  params?: T; 
+  params?: T;
 }
 
 export interface JsonRpcResponse<T> {
@@ -32,11 +32,11 @@ export interface JsonRpcResponse<T> {
 }
 
 export interface JsonRpcSuccess<T> extends JsonRpcResponse<T> {
-    result: T;
+  result: T;
 }
 
 export interface JsonRpcFailure<T> extends JsonRpcResponse<T> {
-    error: JsonRpcError<T>;
+  error: JsonRpcError<T>;
 }
 
 export interface JsonRpcError<T> {
@@ -66,21 +66,21 @@ export const INTERNAL_ERROR = -32603;
 //
 //
 /** Determine if data is a properly formatted JSONRPC 2.0 ID. */
-export function isJsonRpcId(input: JsonRpcId|any): input is JsonRpcId {
-    switch(typeof input) {
-        case "string":
-          return true;
-        case "number":
-          return input % 1 != 0;
-        case "object":
-          let isNull = input === null;
-          if(isNull) {
-              console.warn("Use of null ID in JSONRPC 2.0 is discouraged.");
-              return true;
-          } else {
-              return false;
-          }
-        default:
-          return false;
-    }
+export function isJsonRpcId(input: JsonRpcId | any): input is JsonRpcId {
+  switch (typeof input) {
+    case "string":
+      return true;
+    case "number":
+      return input % 1 != 0;
+    case "object":
+      let isNull = input === null;
+      if (isNull) {
+        console.warn("Use of null ID in JSONRPC 2.0 is discouraged.");
+        return true;
+      } else {
+        return false;
+      }
+    default:
+      return false;
+  }
 }

--- a/app/libs/src/metapage/v0_3/JsonRpcMethods.ts
+++ b/app/libs/src/metapage/v0_3/JsonRpcMethods.ts
@@ -1,7 +1,6 @@
 import { MetaframeId, MetapageId, MetaframeInputMap, Versions } from "./all";
 import { JsonRpcRequest } from '../jsonrpc2';
 
-
 export enum JsonRpcMethodsFromChild {
   InputsUpdate = "InputsUpdate",
   OutputsUpdate = "OutputsUpdate",
@@ -17,11 +16,6 @@ export enum JsonRpcMethodsFromParent {
   InputsUpdate = "InputsUpdate",
   MessageAck = "MessageAck",
   SetupIframeServerResponse = "SetupIframeServerResponse"
-}
-
-export type HashParamsUpdatePayload = {
-  metaframe: MetaframeId;
-  hash: string;
 }
 
 export interface SetupIframeServerResponseData {

--- a/app/libs/src/metapage/v0_3/JsonRpcMethods.ts
+++ b/app/libs/src/metapage/v0_3/JsonRpcMethods.ts
@@ -8,7 +8,9 @@ export enum JsonRpcMethodsFromChild {
   SetupIframeClientRequest = "SetupIframeClientRequest",
   SetupIframeServerResponseAck = "SetupIframeServerResponseAck",
   // Plugin API
-  PluginRequest = "SetupIframeServerPluginRequestResponseAck" // See further definitions: ApiPayloadPluginRequest*
+  PluginRequest = "SetupIframeServerPluginRequestResponseAck", // See further definitions: ApiPayloadPluginRequest*
+  // Experimental feature
+  HashParamsUpdate = "HashParamsUpdate",
 }
 
 export enum JsonRpcMethodsFromParent {
@@ -17,8 +19,8 @@ export enum JsonRpcMethodsFromParent {
   SetupIframeServerResponse = "SetupIframeServerResponse"
 }
 
-export enum OtherEvents {
-  Message = "Message"
+export type HashParamsUpdatePayload = {
+  hash: string;
 }
 
 export interface SetupIframeServerResponseData {

--- a/app/libs/src/metapage/v0_3/JsonRpcMethods.ts
+++ b/app/libs/src/metapage/v0_3/JsonRpcMethods.ts
@@ -1,5 +1,5 @@
-import {MetaframeId, MetapageId, MetaframeInputMap, Versions} from "./all";
-import {JsonRpcRequest} from '../jsonrpc2';
+import { MetaframeId, MetapageId, MetaframeInputMap, Versions } from "./all";
+import { JsonRpcRequest } from '../jsonrpc2';
 
 
 export enum JsonRpcMethodsFromChild {
@@ -20,6 +20,7 @@ export enum JsonRpcMethodsFromParent {
 }
 
 export type HashParamsUpdatePayload = {
+  metaframe: MetaframeId;
   hash: string;
 }
 

--- a/app/libs/test/page/index.template.html
+++ b/app/libs/test/page/index.template.html
@@ -445,6 +445,13 @@ window.onload = function() {
     const metapageInstance = Metapage.from(metaPageDefinition);
     window.metapageInstance = metapageInstance;
 
+    // New as of >=0.5.12
+    if (Metapage.DEFINITION_UPDATE_REQUEST) {
+        metapageInstance.addListener(Metapage.DEFINITION_UPDATE_REQUEST, (newDefinition) => {
+            metapageInstance.setDefinition(newDefinition);
+        });
+    }
+
     // window.metapageInstance = Metapage.from(metaPageDefinition);
     // metapageInstance = Metapage.from(metaPageDefinition);
     // window.metapageInstance = metapageInstance


### PR DESCRIPTION
Fixes #80 

- if a metaframe changes it's internal hash params, it notifies the parent metapage, which then updates in place the definition and fires an event. 
- this update cannot be stopped since it is the metaframe itself, and hash params should be known to the metapage since its state
- if a plugin emits a new definition, it is an update *request* and handled explicitly by event handlers, so not updating automatically