### PR TITLE
Set iframe.src before adding to dom.

### DIFF
--- a/app/docs/pages/04_api.md
+++ b/app/docs/pages/04_api.md
@@ -5,7 +5,7 @@ permalink: /api/
 nav_order: 4
 ---
 
-# API Reference v0.4.3
+# API Reference v0.8.0
 {: .no_toc }
 
 ###### <a href="/versions">previous versions</a>
@@ -167,15 +167,6 @@ metapage.getMetaframe(metaframeId :String): MetaframeClient
 ```
 
 Get the MetaframeClient for the given id.
-
-### Metapage#getIframes
-
-```ts
-metapage.getIframes(): Map<String, IFrameElement>
-```
-
-Returns a plain Object with metaframe ids mapped to the underlying metaframe [iframes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe).
-
 
 ### Metapage#getMetaframeIds
 
@@ -445,7 +436,9 @@ const url :string = metapage.getMetaframe(id).url;
 
 ### Metapage.MetaframeClient#iframe
 
-The concrete metaframe [iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) HTML element.
+A promise returning the metaframe [iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) HTML element.
+
+This must be a promise because the `metaframe.json` file is downloaded and used to help construct the iframe (e.g. permissions)
 
 ### Metapage.MetaframeClient#dispose
 

--- a/app/libs/package.json
+++ b/app/libs/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@metapages/metapage",
     "public": true,
-    "version": "0.7.0",
+    "version": "0.8.0",
     "description": "Connect web pages together",
     "repository": "https://github.com/metapages/metapage",
     "homepage": "https://metapages.org/",

--- a/app/libs/test/page/index.template.html
+++ b/app/libs/test/page/index.template.html
@@ -376,7 +376,7 @@ const convertNpmToInternalVersion = (version) => {
 ////////////////////////////////////////////////////////////////////////
 // After the window loads the specific versiono of the metapage library
 // set the test machinery up and run the tests
-window.onload = function() {
+window.onload = async () => {
     console.log(`TEST-MP: Metapage ${convertNpmToInternalVersion(VERSION)}`);
 
     // Define the metapage definition dynamically
@@ -496,7 +496,8 @@ window.onload = function() {
     var metaframeIds = metapageInstance.metaframeIds();
     var pluginsIds = metaPageDefinition.plugins ? metaPageDefinition.plugins.concat([]) : [];
     // Add the metaframe (and plugin) iframes to the page
-    metaframeIds.forEach((metaframeId) => {
+
+    for (const metaframeId of metaframeIds) {
         var row = document.createElement("div");
         row.className += row.className ? ' row' : 'row';
 
@@ -509,16 +510,17 @@ window.onload = function() {
         row.appendChild(col1);
         row.appendChild(col2);
 
-
-        col1.appendChild(metapageInstance.getMetaframe(metaframeId).iframe);
+        const iframe = await metapageInstance.getMetaframe(metaframeId).iframe;
+        col1.appendChild(iframe);
 
         if (pluginsIds.length > 0) {
             const pluginId = pluginsIds.shift();
-            col2.appendChild(metapageInstance.getPlugin(pluginId).iframe);
+            const pluginIframe = await metapageInstance.getPlugin(pluginId).iframe;
+            col2.appendChild(pluginIframe);
         }
 
         document.getElementById("body").appendChild(row);
-    });
+    }
 
     Promise.all(promises)
         .then(() => {


### PR DESCRIPTION
Fixes #91

Before the metaframe iframe element is returned, download the `metaframe.json` to modify permissions and set the `src` attribute BEFORE adding to the dom to prevent back button frustruations.
