### PR TITLE
allow sending undefined

### DIFF
--- a/app/libs/.gitignore
+++ b/app/libs/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .cache
 .env
+.npmrc
 node_modules/
 tmp/
 site

--- a/app/libs/Dockerfile
+++ b/app/libs/Dockerfile
@@ -97,7 +97,7 @@ RUN apk add --virtual .download --no-cache curl ; \
 
 # USER chrome
 
-RUN npm install -g npm@7.6.0
+RUN npm install -g npm@7.23.0
 
 #################################################################
 # libs: setup

--- a/app/libs/Dockerfile
+++ b/app/libs/Dockerfile
@@ -25,6 +25,9 @@ RUN VERSION=0.8.4 ; \
     mkdir -p /usr/local/bin && mv /tmp/just/just /usr/local/bin/ && rm -rf /tmp/just
 # just tweak: unify the just binary location on host and container platforms because otherwise the shebang doesn't work properly due to no string token parsing (it gets one giant string)
 ENV PATH $PATH:/usr/local/bin
+# alias "j" to just, it's just right there index finger
+RUN echo -e '#!/bin/bash\njust "$@"' > /usr/bin/j && \
+    chmod +x /usr/bin/j
 
 # watchexec for live reloading in development https://github.com/watchexec/watchexec
 RUN VERSION=1.14.1 ; \

--- a/app/libs/package-lock.json
+++ b/app/libs/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@metapages/metapage",
-    "version": "0.6.0",
+    "version": "0.8.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@metapages/metapage",
-            "version": "0.6.0",
+            "version": "0.8.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "compare-versions": "^3.6.0",
@@ -3203,6 +3203,7 @@
             "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.21.tgz",
             "integrity": "sha512-kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==",
             "dev": true,
+            "hasInstallScript": true,
             "dependencies": {
                 "bindings": "^1.5.0",
                 "node-addon-api": "^1.7.1"
@@ -4348,6 +4349,7 @@
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
             "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
             "dev": true,
+            "hasInstallScript": true,
             "optional": true,
             "os": [
                 "darwin"


### PR DESCRIPTION
It's dumb to fail when you send `undefined` as a pipe value since that's a valid value.
Also fails on sending `false` which is really bad.