### PR TITLE
Better descriptive and unified metadata, and metaframe edit descriptions

### DIFF
--- a/app/libs/src/metapage/v0_4/metaframe.ts
+++ b/app/libs/src/metapage/v0_4/metaframe.ts
@@ -1,58 +1,82 @@
-import { MetaframeId, MetaframePipeId } from './core';
-import { VersionsMetaframe } from './versions';
+import { MetaframeId, MetaframePipeId } from "./core";
+import { VersionsMetaframe } from "./versions";
+import { MetapageDefinition } from "../v0_3/all";
 
 export interface PipeInput {
-    metaframe: MetaframeId;
-    source: MetaframePipeId;
-    target: MetaframePipeId;
+  metaframe: MetaframeId;
+  source: MetaframePipeId;
+  target: MetaframePipeId;
 }
 
 export interface PipeUpdateBlob {
-    name: MetaframePipeId;
-    value: any;
+  name: MetaframePipeId;
+  value: any;
 }
 
 export type MetaframePipeDefinition = {
-    type?: string;
+  type?: string;
+};
+
+export type MetaframeEditType = "metapage" | "metaframe";
+
+export type MetaframeEditTypeMetaframe = {
+  url: string;
+  // from the target metaframe to the edit metaframe
+  // we can only get hash params from the edit metaframe but those
+  // might map to path or search elements on the target metaframe
+  params?: {
+    from: string; // this is a hash param, it's the only param we can get from a metaframe
+    to: string;
+    toType: "search" | "hash" | "path";
+  }[];
+};
+
+// the metaframe name to get the hash params is "edit"
+export type MetaframeEditTypeMetapage = {
+  definition: MetapageDefinition;
+  key?: string; // default is "edit"
 };
 
 export type MetaframeMetadata = {
-    version?: string;
-    title?: string;
-    author?: string;
-    image?: string;
-    descriptionUrl?: string;
-    keywords?: string[];
-    iconUrl?: string;
+  version?: string;
+  name?: string;
+  description?: string;
+  author?: string;
+  image?: string;
+  keywords?: string[];
+  edit: {
+    type: MetaframeEditType;
+    value: MetaframeEditTypeMetaframe | MetaframeEditTypeMetapage;
+  };
 };
 
 export interface MetaframeDefinition {
-    version?: VersionsMetaframe;
-    inputs?: {
-        [key: string]: MetaframePipeDefinition
-    }; // <MetaframePipeId, MetaframePipeDefinition>
-    outputs?: {
-        [key: string]: MetaframePipeDefinition
-    }; // <MetaframePipeId, MetaframePipeDefinition>
-    metadata: MetaframeMetadata;
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy#the_iframe_allow_attribute
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#directives
-    allow?: string;
+  version?: VersionsMetaframe;
+  inputs?: {
+    [key: string]: MetaframePipeDefinition;
+  }; // <MetaframePipeId, MetaframePipeDefinition>
+  outputs?: {
+    [key: string]: MetaframePipeDefinition;
+  }; // <MetaframePipeId, MetaframePipeDefinition>
+  metadata: MetaframeMetadata;
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy#the_iframe_allow_attribute
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#directives
+  allow?: string;
 }
 
 export interface PipeInput {
-    metaframe: MetaframeId;
-    source: MetaframePipeId;
-    target: MetaframePipeId;
+  metaframe: MetaframeId;
+  source: MetaframePipeId;
+  target: MetaframePipeId;
 }
 
 export interface PipeUpdateBlob {
-    name: MetaframePipeId;
-    value: any;
+  name: MetaframePipeId;
+  value: any;
 }
 
 export interface MetaframeInstance {
-    url: string;
-    // Defines the inputs pipes from other metaframes
-    inputs?: PipeInput[];
+  url: string;
+  // Defines the inputs pipes from other metaframes
+  inputs?: PipeInput[];
 }

--- a/app/libs/src/metapage/v0_4/metaframe.ts
+++ b/app/libs/src/metapage/v0_4/metaframe.ts
@@ -37,20 +37,29 @@ export type MetaframeEditTypeMetapage = {
   key?: string; // default is "edit"
 };
 
-export type MetaframeMetadata = {
+export type MetaframeMetadataV4 = {
   version?: string;
+  title?: string;
+  author?: string;
+  image?: string;
+  descriptionUrl?: string;
+  keywords?: string[];
+  iconUrl?: string;
+};
+
+export type MetaframeMetadataV5 = {
   name?: string;
   description?: string;
   author?: string;
   image?: string;
-  keywords?: string[];
-  edit: {
+  tags?: string[];
+  edit?: {
     type: MetaframeEditType;
     value: MetaframeEditTypeMetaframe | MetaframeEditTypeMetapage;
   };
 };
 
-export interface MetaframeDefinition {
+export interface MetaframeDefinitionV4 {
   version?: VersionsMetaframe;
   inputs?: {
     [key: string]: MetaframePipeDefinition;
@@ -58,7 +67,21 @@ export interface MetaframeDefinition {
   outputs?: {
     [key: string]: MetaframePipeDefinition;
   }; // <MetaframePipeId, MetaframePipeDefinition>
-  metadata: MetaframeMetadata;
+  metadata: MetaframeMetadataV4;
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy#the_iframe_allow_attribute
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#directives
+  allow?: string;
+}
+
+export interface MetaframeDefinitionV5 {
+  version: VersionsMetaframe;
+  inputs?: {
+    [key: string]: MetaframePipeDefinition;
+  }; // <MetaframePipeId, MetaframePipeDefinition>
+  outputs?: {
+    [key: string]: MetaframePipeDefinition;
+  }; // <MetaframePipeId, MetaframePipeDefinition>
+  metadata?: MetaframeMetadataV5;
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy#the_iframe_allow_attribute
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#directives
   allow?: string;

--- a/app/libs/src/metapage/v0_4/metapage.ts
+++ b/app/libs/src/metapage/v0_4/metapage.ts
@@ -1,39 +1,44 @@
-import { VersionsMetapage } from './versions';
-import { MetapageId, Url } from './core';
-import { MetaframeInstance } from './metaframe';
+import { VersionsMetapage } from "./versions";
+import { MetapageId, Url } from "./core";
+import { MetaframeInstance } from "./metaframe";
 
 export interface MetapageOptions {
-    id?: MetapageId;
-    color?: string;
+  id?: MetapageId;
+  color?: string;
 }
 
 export type MetapageMetadata = {
-    name?: string;
-    description?: string;
-    // the idea is there *could* be different ways of displaying the metapage, so we store the preferred ways here
-    // you cannot really bake in which one is the "default" since that is not under our control nor should we care
-    // but we can have preferences
-    layouts?: {
-        [key in string]: any
-    };
-    // layout?: MetapageMetadataLayout;
+  name?: string;
+  description?: string;
+  author?: string;
+  image?: string;
+  keywords?: string[];
+  // the idea is there *could* be different ways of displaying the metapage, so we store the preferred ways here
+  // you cannot really bake in which one is the "default" since that is not under our control nor should we care
+  // but we can have preferences
+  layouts?: {
+    [key in string]: any;
+  };
+  // layout?: MetapageMetadataLayout;
 };
 
 export interface MetapageDefinition {
-    id?: MetapageId;
-    // Best to require this even if annoying to users. It's like the docker-compose.yml version. Human velocity changes (slow but steady)
-    version: VersionsMetapage;
-    metaframes: { [key: string]: MetaframeInstance; };
-    // The plugin URLs point to the path containing a MetaframeInstance JSON
-    // It's an array because it needs to be sorted, but currently don't allow duplicate plugin URLs
-    meta?: MetapageMetadata;
-    // The plugin URLs point to the path containing a MetaframeInstance JSON
-    // It's an array because it needs to be sorted, but currently don't allow duplicate plugin URLs
-    plugins?: Url[];
+  id?: MetapageId;
+  // Best to require this even if annoying to users. It's like the docker-compose.yml version. Human velocity changes (slow but steady)
+  version: VersionsMetapage;
+  metaframes: { [key: string]: MetaframeInstance };
+  // The plugin URLs point to the path containing a MetaframeInstance JSON
+  // It's an array because it needs to be sorted, but currently don't allow duplicate plugin URLs
+  meta?: MetapageMetadata;
+  // The plugin URLs point to the path containing a MetaframeInstance JSON
+  // It's an array because it needs to be sorted, but currently don't allow duplicate plugin URLs
+  plugins?: Url[];
 }
 
 export type MetaframeInputMap = {
-    [key: string]: any
+  [key: string]: any;
 }; // key: MetaframePipeId
 
-export interface MetapageInstanceInputs { [key: string]: MetaframeInputMap; };
+export interface MetapageInstanceInputs {
+  [key: string]: MetaframeInputMap;
+}

--- a/app/libs/src/metapage/v0_4/versions.ts
+++ b/app/libs/src/metapage/v0_4/versions.ts
@@ -4,6 +4,7 @@
 export enum VersionsMetaframe {
 	V0_3 = "0.3",
 	V0_4 = "0.4",
+	V0_5 = "0.5",
 }
 
 export enum VersionsMetapage {
@@ -13,7 +14,7 @@ export enum VersionsMetapage {
 
 export const MetaframeVersionsAll = Object.keys(VersionsMetaframe);
 
-export const MetaframeVersionCurrent = VersionsMetaframe.V0_4;
+export const MetaframeVersionCurrent = VersionsMetaframe.V0_5;
 
 export const MetapageVersionsAll = Object.keys(VersionsMetapage);
 

--- a/app/libs/test/page/metaframe/metaframe.json
+++ b/app/libs/test/page/metaframe/metaframe.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.3",
+	"version": "0.5",
 	"inputs": {
 		"metapage/definition": {
 			"type": "metapage/definition"


### PR DESCRIPTION
Fixes #108 

Metaframes can now describe how the can be edited:

```
export type MetaframeEditType = "metapage" | "metaframe";

export type MetaframeEditTypeMetaframe = {
  url: string;
  // from the target metaframe to the edit metaframe
  // we can only get hash params from the edit metaframe but those
  // might map to path or search elements on the target metaframe
  params?: {
    from: string; // this is a hash param, it's the only param we can get from a metaframe
    to: string;
    toType: "search" | "hash" | "path";
  }[];
};

// the metaframe name to get the hash params is "edit"
export type MetaframeEditTypeMetapage = {
  definition: MetapageDefinition;
  key?: string; // default is "edit"
};

export type MetaframeMetadata = {
  version?: string;
  name?: string;
  description?: string;
  author?: string;
  image?: string;
  keywords?: string[];
  edit: {
    type: MetaframeEditType;
    value: MetaframeEditTypeMetaframe | MetaframeEditTypeMetapage;
  };
};
```