### PR TITLE
Fail the publish job when publishing fails

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,20 +46,51 @@ jobs:
       - name: publish module
         id: publish
         run: |
+          set -euo pipefail
+
           # Capture version before publishing
-          VERSION=$(cat lib/package.json | jq -r '.version')
+          VERSION=$(jq -r '.version' lib/package.json)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-          # Run publish and capture if it actually published
-          OUTPUT=$(just lib/publish 2>&1) || true
-          echo "$OUTPUT"
+          # `tee` rather than `OUTPUT=$(...)` so the log streams live, and no
+          # `|| true`: a failing publish MUST fail the job. It used to be
+          # swallowed, so a broken publish (e.g. a missing tool in the recipe)
+          # reported success, silently skipped the release, and left the version
+          # unpublished with a green check mark.
+          if ! just lib/publish 2>&1 | tee publish.log; then
+            echo "::error::'just lib/publish' failed - see the log above"
+            exit 1
+          fi
 
-          # Check if version was actually published (not skipped)
-          if echo "$OUTPUT" | grep -q "PUBLISHING npm version"; then
+          # Publishing is idempotent: an already-published version is a no-op,
+          # not a failure, and must not cut a duplicate release.
+          if grep -q "PUBLISHING npm version" publish.log; then
             echo "published=true" >> $GITHUB_OUTPUT
           else
             echo "published=false" >> $GITHUB_OUTPUT
           fi
+
+      # Belt and braces: the step above can only report what the recipe told it.
+      # This asserts the actual end state against the registry, so any future
+      # way of failing quietly still turns the job red.
+      - name: verify version is on npm
+        run: |
+          set -euo pipefail
+          NAME=$(jq -r '.name' lib/package.json)
+          VERSION="${{ steps.publish.outputs.version }}"
+
+          # Registry reads can lag a publish by a few seconds
+          for attempt in 1 2 3 4 5; do
+            if npm view "$NAME@$VERSION" version > /dev/null 2>&1; then
+              echo "✅ $NAME@$VERSION is on npm"
+              exit 0
+            fi
+            echo "$NAME@$VERSION not visible yet (attempt $attempt), retrying..."
+            sleep 10
+          done
+
+          echo "::error::$NAME@$VERSION is not on npm after the publish step"
+          exit 1
 
       - name: Create GitHub Release
         if: steps.publish.outputs.published == 'true'

--- a/lib/README.md
+++ b/lib/README.md
@@ -36,7 +36,7 @@ import {
   renderMetapage,
   Metapage,
   Metaframe,
-} from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.1";
+} from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.12";
 ```
 
 ## Quick Start
@@ -138,7 +138,7 @@ dispose();
   <body>
     <div id="container"></div>
     <script type="module">
-      import { renderMetaframe } from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.8";
+      import { renderMetaframe } from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.12";
 
       const { dispose } = await renderMetaframe({
         url: "https://js.mtfm.io/",
@@ -156,7 +156,7 @@ dispose();
 If you're building a component to use in a metapage:
 
 ```javascript
-import { Metaframe } from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.8";
+import { Metaframe } from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.12";
 
 const metaframe = new Metaframe();
 
@@ -297,7 +297,7 @@ metaframe.onInput("file", (file) => {
     <div id="metapage-container"></div>
 
     <script type="module">
-      import { renderMetapage } from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.1";
+      import { renderMetapage } from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.12";
 
       const definition = await fetch(
         "https://metapage.io/m/87ae11673508447e883b598bf7da9c5d/metapage.json",
@@ -332,7 +332,7 @@ metaframe.onInput("file", (file) => {
 ### Building a Metaframe Component
 
 ```javascript
-import { Metaframe } from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.1";
+import { Metaframe } from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.12";
 
 const metaframe = new Metaframe();
 
@@ -409,7 +409,7 @@ Metaframes can read and write to their URL hash parameters:
 import {
   getHashParamValueJsonFromWindow,
   setHashParamValueJsonInWindow,
-} from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.1";
+} from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.12";
 
 // Read from URL hash
 const config = getHashParamValueJsonFromWindow("config");
@@ -711,7 +711,7 @@ Example minimal metaframe:
   </head>
   <body>
     <script type="module">
-      import { Metaframe } from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.1";
+      import { Metaframe } from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.12";
 
       const metaframe = new Metaframe();
 
@@ -735,7 +735,7 @@ import {
   MetapageDefinition,
   MetaframeInputMap,
   MetapageInstanceInputs,
-} from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.1";
+} from "https://cdn.jsdelivr.net/npm/@metapages/metapage@1.10.12";
 
 const definition: MetapageDefinition = {
   metaframes: {

--- a/lib/justfile
+++ b/lib/justfile
@@ -155,18 +155,24 @@ check-versions-id-docs:
     # Get the versions from the package.json
     VERSION=`cat package.json | jq -r '.version'`
     # Extract all versions used in CDN lines in README.md
-    USED_VERSIONS=$(grep -oE 'https://cdn.jsdelivr.net/npm/@metapages/metapage@([0-9]+\.[0-9]+\.[0-9]+)' README.md | sed -E 's|.*@([0-9]+\.[0-9]+\.[0-9]+)|\1|')
+    # `|| true`: no matches is not a grep crash, it is its own error below.
+    # Without it, pipefail aborts the recipe here with no explanation.
+    USED_VERSIONS=$(grep -oE 'https://cdn.jsdelivr.net/npm/@metapages/metapage@([0-9]+\.[0-9]+\.[0-9]+)' README.md | sed -E 's|.*@([0-9]+\.[0-9]+\.[0-9]+)|\1|' || true)
+    if [[ -z "$USED_VERSIONS" ]]; then
+      echo -e "❌ No @metapages/metapage CDN URLs found in README.md - this check cannot verify anything"
+      exit 1
+    fi
     EXIT_CODE=0
     for used in $USED_VERSIONS; do
       if [[ "$used" != "$VERSION" ]]; then
-        echo -e "❌ Version mismatch: README.md refers to @metapages/metapage@$used but package.json is $$VERSION"
+        echo -e "❌ Version mismatch: README.md refers to @metapages/metapage@$used but package.json is $VERSION"
         EXIT_CODE=1
       fi
     done
     if [[ $EXIT_CODE -ne 0 ]]; then
       exit $EXIT_CODE
     fi
-    echo -e "✅ All CDN versions in README.md match package.json ($$VERSION)"
+    echo -e "✅ All CDN versions in README.md match package.json ($VERSION)"
 
 update-docs-versions:
     #!/usr/bin/env bash
@@ -174,8 +180,12 @@ update-docs-versions:
     echo "🔍 Updating docs versions..."
     # Get the versions from the package.json
     VERSION=`cat package.json | jq -r '.version'`
-    # Update the versions in the docs
-    sd "https://cdn.jsdelivr.net/npm/@metapages/metapage@[^\s\"']*" "https://cdn.jsdelivr.net/npm/@metapages/metapage@${VERSION}" README.md
+    # Update the versions in the docs.
+    # perl, not sd: sd is not installed on the CI runners (nor on a stock dev
+    # machine), and this recipe is a prerequisite of `publish`, so a missing
+    # binary blocks releases. perl ships with macOS and every CI image, and
+    # -pi behaves identically on both, unlike sed -i.
+    VERSION="$VERSION" perl -pi -e 's{(https://cdn\.jsdelivr\.net/npm/\@metapages/metapage\@)[^\s"\x27]*}{$1$ENV{VERSION}}g' README.md
     echo -e "✅ Updated docs versions to $VERSION"
 
 # Unpublish version https://docs.npmjs.com/cli/v7/commands/npm-unpublish


### PR DESCRIPTION
## The problem

`just lib/publish` has been broken since it started depending on [`sd`](https://github.com/chmln/sd), which is not installed on the runners:

```
🔍 Updating docs versions...
line 178: sd: command not found
error: Recipe `update-docs-versions` failed with exit code 127
```

Nobody noticed because the `publish module` step ran it as:

```bash
OUTPUT=$(just lib/publish 2>&1) || true
```

…and then decided whether it worked by grepping the output for `PUBLISHING npm version`. A **failure** and an **already-published version** were indistinguishable: both set `published=false`, skipped the release, and exited 0.

So `1.10.12` was merged (#195), [reported green](https://github.com/metapages/metapage/actions/runs/30468277589/job/90631624494), and never reached npm — `npm view @metapages/metapage version` still returns `1.10.11`.

## The fix

**1. Stop swallowing the exit code.** The recipe's status now fails the step, and output streams live via `tee` instead of being withheld until the end. The "did it actually publish" grep is kept, because skipping an already-published version is still a legitimate no-op.

**2. Drop the `sd` dependency.** Replaced with `perl -pi`, which ships with macOS and every CI image, and whose `-pi` behaves the same on both (unlike `sed -i`). Verified to rewrite exactly the 8 CDN URLs in `lib/README.md` and nothing else.

**3. Assert the end state.** A new step checks the version is really on the registry after publishing. The publish step can only report what the recipe told it; this catches any *future* way of failing quietly, whatever the cause.

Also fixes two paper cuts in `check-versions-id-docs` that made its own failures hard to read: `$$VERSION` printed the shell PID instead of the version, and a README with no CDN URLs aborted the recipe via `pipefail` with no message at all.

`lib/README.md` is committed with the versions the recipe generates, so the tree no longer starts out failing its own check.

## Verified

Simulated the `publish module` step against a stubbed `just`:

| Scenario | Step exit | `published` |
|---|---|---|
| Recipe fails (the `sd` case) | **1** ✅ (was 0) | — |
| Publishes successfully | 0 | `true` |
| Version already on npm | 0 | `false` |

And the recipes directly:
- `just lib/update-docs-versions` → rewrites all 8 URLs to `1.10.12`, byte-identical otherwise
- `just lib/check-versions-id-docs` → passes; fails with a readable message on both version mismatch and a README with no CDN URLs
- `just lib/fmt` → no changes
- npm verification step → passes for `1.10.11`, fails for the unpublished `1.10.12`

## Note

Merging this publishes **1.10.12** (the handshake fix from #195), since that version is still sitting unpublished in `lib/package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)